### PR TITLE
feat(normalize): junk-title filter + cross-run dedup

### DIFF
--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -3,7 +3,12 @@ name: AI Newsletter
 on:
   schedule:
     - cron: '0 14 * * 1'   # Every Monday 6am PST (UTC-8) / 7am PDT (UTC-7)
-  workflow_dispatch:         # Manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Skip Telegram send (still updates seen-state and uploads artifacts)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -134,8 +139,12 @@ jobs:
   deliver:
     needs: summarize
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -146,10 +155,41 @@ jobs:
           name: summarized
           path: data/
       - name: Deliver to Telegram
-        run: python pipeline/deliver.py
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            python pipeline/deliver.py --dry-run
+          else
+            python pipeline/deliver.py
+          fi
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      - name: Upload digest preview (dry-run)
+        if: inputs.dry_run == true
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-preview
+          path: data/digest_preview.txt
+          if-no-files-found: warn
+      - name: Upload normalized + summarized (verification)
+        uses: actions/upload-artifact@v4
+        with:
+          name: deliver-inputs
+          path: |
+            data/summarized.json
+            state/seen.json
+          if-no-files-found: warn
+      - name: Commit updated seen-state
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add state/seen.json
+          if git diff --staged --quiet; then
+            echo "No seen-state changes to commit."
+          else
+            git commit -m "chore: update state/seen.json [skip ci]"
+            git push origin HEAD:${{ github.ref_name }}
+          fi
 
   publish:
     needs: deliver

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,11 @@ data/*
 # Editor
 .vscode/
 .idea/
+
+# Local test scratch (downloaded artifacts, normalize replay)
+tmp_artifacts/
+tmp_latest/
+tmp_latest2/
+tmp_real_run/
+tmp_runs/
+tmp_normalize_test/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ data/*
 .env
 *.env
 
+# Git worktrees
+.worktrees/
+
 # Editor
 .vscode/
 .idea/

--- a/docs/superpowers/plans/2026-04-11-newsletter-wiki-integration.md
+++ b/docs/superpowers/plans/2026-04-11-newsletter-wiki-integration.md
@@ -1,0 +1,1029 @@
+# Newsletter Wiki Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add wiki output to the newsletteragent pipeline and centralise LLM backend selection so the full pipeline runs locally with Gemma3 (LLM_BACKEND=local) or in CI with GitHub Models (LLM_BACKEND=github, default).
+
+**Architecture:** A new `pipeline/llm_config.py` module exposes `get_client(step) -> (OpenAI, model_name)` and is imported by rank, summarize, and wiki steps. `pipeline/wiki.py` reads `data/summarized.json` and writes story articles, topic articles, a weekly digest, and an index to `D:/myprojects/wiki/`. `pipeline/run.py` chains all steps locally and pings Ollama if LLM_BACKEND=local.
+
+**Tech Stack:** Python 3.11+, openai SDK, httpx, pydantic, pytest, monkeypatch
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `pipeline/llm_config.py` | Central LLM config — `get_client(step)` returns `(OpenAI, model_name)` |
+| Create | `pipeline/wiki.py` | Wiki build step — reads `summarized.json`, writes to `D:/myprojects/wiki/` |
+| Create | `pipeline/run.py` | Local full-pipeline runner — chains all steps |
+| Create | `tests/pipeline/test_llm_config.py` | Unit tests for llm_config |
+| Create | `tests/pipeline/test_wiki.py` | Unit tests for wiki step |
+| Create | `tests/pipeline/test_run.py` | Unit test for run.py Ollama ping |
+| Modify | `pipeline/rank.py` | Remove local `get_client()`, add `model` param to rank/classify functions, use llm_config in main() |
+| Modify | `pipeline/summarize.py` | Remove `get_client` import from rank, add `model` param to `summarize_story`, use llm_config in main() |
+| Modify | `tests/pipeline/test_rank.py` | Update monkeypatch target from `mod.get_client` to `pipeline.llm_config.get_client` |
+| Modify | `tests/pipeline/test_summarize.py` | Same update + update `fake_summarize` signature |
+
+---
+
+## Task 1: pipeline/llm_config.py
+
+**Files:**
+- Create: `pipeline/llm_config.py`
+- Create: `tests/pipeline/test_llm_config.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/pipeline/test_llm_config.py
+import importlib
+import sys
+import pytest
+from unittest.mock import patch
+
+
+def _load(monkeypatch, backend=None):
+    """Delete cached module and re-import with the given env var."""
+    if backend is not None:
+        monkeypatch.setenv("LLM_BACKEND", backend)
+    else:
+        monkeypatch.delenv("LLM_BACKEND", raising=False)
+    monkeypatch.delitem(sys.modules, "pipeline.llm_config", raising=False)
+    return importlib.import_module("pipeline.llm_config")
+
+
+def test_github_backend_is_default(monkeypatch):
+    mod = _load(monkeypatch)
+    assert mod.LLM_BACKEND == "github"
+    client, model = mod.get_client("rank")
+    assert model == "openai/gpt-4o-mini"
+    assert "github" in str(client.base_url)
+
+
+def test_local_backend(monkeypatch):
+    mod = _load(monkeypatch, "local")
+    assert mod.LLM_BACKEND == "local"
+    client, model = mod.get_client("rank")
+    assert model == "gemma3"
+    assert "11434" in str(client.base_url)
+
+
+def test_unknown_backend_raises(monkeypatch):
+    monkeypatch.setenv("LLM_BACKEND", "bogus")
+    monkeypatch.delitem(sys.modules, "pipeline.llm_config", raising=False)
+    with pytest.raises(ValueError, match="Unknown LLM_BACKEND"):
+        importlib.import_module("pipeline.llm_config")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd D:/myprojects/newsletteragent
+pytest tests/pipeline/test_llm_config.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'pipeline.llm_config'`
+
+- [ ] **Step 3: Create pipeline/llm_config.py**
+
+```python
+# pipeline/llm_config.py
+import os
+from openai import OpenAI
+
+LLM_BACKEND = os.environ.get("LLM_BACKEND", "github")
+
+BACKENDS = {
+    "github": {
+        "base_url": "https://models.github.ai/inference",
+        "api_key": os.environ.get("GITHUB_TOKEN", ""),
+        "models": {
+            "rank":      "openai/gpt-4o-mini",
+            "summarize": "openai/gpt-4o",
+            "wiki":      "openai/gpt-4o-mini",
+        },
+    },
+    "local": {
+        "base_url": "http://localhost:11434/v1",
+        "api_key": "ollama",
+        "models": {
+            "rank":      "gemma3",
+            "summarize": "gemma3",
+            "wiki":      "gemma3",
+        },
+    },
+}
+
+if LLM_BACKEND not in BACKENDS:
+    raise ValueError(
+        f"Unknown LLM_BACKEND '{LLM_BACKEND}'. Must be one of: {list(BACKENDS)}"
+    )
+
+
+def get_client(step: str) -> tuple[OpenAI, str]:
+    """Return (OpenAI client, model name) for the given pipeline step."""
+    backend = BACKENDS[LLM_BACKEND]
+    client = OpenAI(base_url=backend["base_url"], api_key=backend["api_key"])
+    return client, backend["models"][step]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+pytest tests/pipeline/test_llm_config.py -v
+```
+
+Expected: 3 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/llm_config.py tests/pipeline/test_llm_config.py
+git commit -m "feat: add pipeline/llm_config.py with LLM_BACKEND switching"
+```
+
+---
+
+## Task 2: Refactor pipeline/rank.py
+
+**Files:**
+- Modify: `pipeline/rank.py`
+- Modify: `tests/pipeline/test_rank.py`
+
+The change: remove the local `get_client()` function, add `model` parameter to `rank_story()`, `rank_batch()`, and `classify_sdlc_tags()`, and update `main()` to get (client, model) from `llm_config`.
+
+- [ ] **Step 1: Verify current tests pass before touching anything**
+
+```
+pytest tests/pipeline/test_rank.py -v
+```
+
+Expected: all passing. Note the count — you must not regress any test.
+
+- [ ] **Step 2: Add model parameter to rank_story, rank_batch, classify_sdlc_tags**
+
+In `pipeline/rank.py`:
+
+**Remove** the entire `get_client()` function (lines 157–164 — the function that creates the OpenAI client with the GITHUB_TOKEN).
+
+**Change `rank_story` signature** from:
+```python
+def rank_story(story: Story, client: OpenAI) -> Story | None:
+```
+to:
+```python
+def rank_story(story: Story, client: OpenAI, model: str = "openai/gpt-4o-mini") -> Story | None:
+```
+Replace the hardcoded `model="openai/gpt-4o-mini"` inside it with the `model` variable:
+```python
+response = client.chat.completions.create(
+    model=model,
+    ...
+)
+```
+
+**Change `rank_batch` signature** from:
+```python
+def rank_batch(batch: list[Story], client: OpenAI, retries: int = 2) -> list[Story]:
+```
+to:
+```python
+def rank_batch(batch: list[Story], client: OpenAI, model: str = "openai/gpt-4o-mini", retries: int = 2) -> list[Story]:
+```
+Replace both hardcoded `model="openai/gpt-4o-mini"` inside it with the `model` variable.
+
+**Change `classify_sdlc_tags` signature** from:
+```python
+def classify_sdlc_tags(stories: list[Story], client: OpenAI) -> list[Story]:
+```
+to:
+```python
+def classify_sdlc_tags(stories: list[Story], client: OpenAI, model: str = "openai/gpt-4o-mini") -> list[Story]:
+```
+Replace hardcoded `model="openai/gpt-4o-mini"` inside it with the `model` variable.
+
+**Update `main()`** — replace:
+```python
+def main():
+    client = get_client()
+    source_weights = _load_source_weights()
+    ...
+    results = rank_batch(batch, client)
+    ...
+    ranked = classify_sdlc_tags(ranked, client)
+```
+with:
+```python
+def main():
+    from pipeline import llm_config
+    client, model = llm_config.get_client("rank")
+    source_weights = _load_source_weights()
+    ...
+    results = rank_batch(batch, client, model)
+    ...
+    ranked = classify_sdlc_tags(ranked, client, model)
+```
+
+Also pass `model` to the `rank_story` call if present anywhere in main (there isn't one in main — rank_story is only in unit tests and backwards-compat path).
+
+- [ ] **Step 3: Run rank tests to verify nothing regressed**
+
+```
+pytest tests/pipeline/test_rank.py -v
+```
+
+Expected: same count passing as Step 1. The existing tests don't pass `model` so they use the default.
+
+- [ ] **Step 4: Update the one test that mocks get_client**
+
+In `tests/pipeline/test_rank.py`, find `test_14_day_cutoff_in_main`. It currently has:
+```python
+monkeypatch.setattr(mod, "get_client", lambda: None)
+```
+
+Replace those two lines with:
+```python
+import pipeline.llm_config
+monkeypatch.setattr(pipeline.llm_config, "get_client", lambda step: (None, "openai/gpt-4o-mini"))
+```
+
+Also remove `get_client` from the import at the top of that test file if it's there (it isn't — check line 4: imports are from `pipeline.rank` but not `get_client`).
+
+- [ ] **Step 5: Run tests again**
+
+```
+pytest tests/pipeline/test_rank.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pipeline/rank.py tests/pipeline/test_rank.py
+git commit -m "refactor: rank.py uses llm_config.get_client, adds model param"
+```
+
+---
+
+## Task 3: Refactor pipeline/summarize.py
+
+**Files:**
+- Modify: `pipeline/summarize.py`
+- Modify: `tests/pipeline/test_summarize.py`
+
+Current state: `summarize.py` imports `get_client` from `pipeline.rank` and uses `model="openai/gpt-4o"` hardcoded in `summarize_story()`.
+
+- [ ] **Step 1: Verify current tests pass**
+
+```
+pytest tests/pipeline/test_summarize.py -v
+```
+
+Note the passing count.
+
+- [ ] **Step 2: Update summarize.py imports and add model parameter**
+
+In `pipeline/summarize.py`:
+
+**Change line 13** from:
+```python
+from pipeline.rank import get_client, recency_multiplier
+```
+to:
+```python
+from pipeline.rank import recency_multiplier
+from pipeline import llm_config
+```
+
+**Change `summarize_story` signature** from:
+```python
+def summarize_story(story: Story, client: OpenAI, cache: dict | None = None) -> Story:
+```
+to:
+```python
+def summarize_story(story: Story, client: OpenAI, model: str = "openai/gpt-4o", cache: dict | None = None) -> Story:
+```
+
+Inside `summarize_story`, replace:
+```python
+response = client.chat.completions.create(
+    model="openai/gpt-4o",  # best available on GitHub Models API
+```
+with:
+```python
+response = client.chat.completions.create(
+    model=model,
+```
+
+**Update `main()`** — replace:
+```python
+def main():
+    client = get_client()
+```
+with:
+```python
+def main():
+    client, model = llm_config.get_client("summarize")
+```
+
+Then update the `summarize_story` calls in main. Current:
+```python
+top3 = [summarize_story(s, client, cache) for s in top3]
+```
+Change to:
+```python
+top3 = [summarize_story(s, client, model, cache) for s in top3]
+```
+
+- [ ] **Step 3: Run tests to check for regressions**
+
+```
+pytest tests/pipeline/test_summarize.py -v
+```
+
+Expected: most tests pass. `test_main_summarises_only_top3` may fail because it still patches `mod.get_client`.
+
+- [ ] **Step 4: Update test_main_summarises_only_top3**
+
+In `tests/pipeline/test_summarize.py`, in `test_main_summarises_only_top3`:
+
+Replace:
+```python
+monkeypatch.setattr(mod, "get_client", lambda: None)
+```
+with:
+```python
+import pipeline.llm_config
+monkeypatch.setattr(pipeline.llm_config, "get_client", lambda step: (None, "openai/gpt-4o"))
+```
+
+Also update `fake_summarize` signature from:
+```python
+def fake_summarize(story, client, cache=None):
+```
+to:
+```python
+def fake_summarize(story, client, model="openai/gpt-4o", cache=None):
+```
+
+- [ ] **Step 5: Run all tests**
+
+```
+pytest tests/pipeline/test_summarize.py -v
+```
+
+Expected: all passing (same count as Step 1).
+
+- [ ] **Step 6: Run the full test suite to check cross-module**
+
+```
+pytest tests/ -v --tb=short
+```
+
+Expected: no new failures introduced by the refactor.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pipeline/summarize.py tests/pipeline/test_summarize.py
+git commit -m "refactor: summarize.py uses llm_config.get_client, adds model param"
+```
+
+---
+
+## Task 4: pipeline/wiki.py — pure-Python functions
+
+This task creates `pipeline/wiki.py` with the helpers and story-article/index functions. No LLM calls yet.
+
+**Files:**
+- Create: `pipeline/wiki.py` (partial — helpers + story + index)
+- Create: `tests/pipeline/test_wiki.py` (partial — story + index tests)
+
+- [ ] **Step 1: Write the failing tests (story articles + index)**
+
+```python
+# tests/pipeline/test_wiki.py
+import pytest
+from datetime import date, datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from schemas.story import Story, StorySummary
+from pipeline.wiki import write_story_articles, write_index
+
+
+def _make_story(title="GPT-5 Launches", sdlc_tags=None, has_summary=True):
+    story = Story.from_url(
+        url="https://example.com/gpt-5",
+        title=title,
+        source_name="OpenAI",
+        published_at=datetime(2026, 4, 11, tzinfo=timezone.utc),
+        raw_content="OpenAI launched GPT-5 today.",
+    )
+    story.sdlc_tags = sdlc_tags or ["ai-agents"]
+    if has_summary:
+        story.summary = StorySummary(
+            what_happened="GPT-5 launched with enterprise API.",
+            enterprise_impact="Enterprises can integrate GPT-5.",
+            software_delivery_impact="Dev pipelines improve.",
+            developer_impact="New endpoints available.",
+            human_impact="Society benefits from better AI.",
+            how_to_use="Upgrade your OpenAI SDK.",
+        )
+    return story
+
+
+def test_story_article_written(tmp_path):
+    story = _make_story()
+    paths = write_story_articles([story], tmp_path)
+
+    assert len(paths) == 1
+    content = paths[0].read_text(encoding="utf-8")
+    assert "GPT-5" in content
+    assert "## What Happened" in content
+    assert "enterprise API" in content
+    assert "## How To Use" in content
+
+
+def test_story_article_no_llm_call(tmp_path):
+    """write_story_articles is pure Python — it takes no client parameter."""
+    import inspect
+    from pipeline.wiki import write_story_articles as fn
+    sig = inspect.signature(fn)
+    assert "client" not in sig.parameters
+
+
+def test_story_article_skips_no_summary(tmp_path):
+    story = _make_story(has_summary=False)
+    paths = write_story_articles([story], tmp_path)
+    assert paths == []
+
+
+def test_story_article_dedupes_by_id(tmp_path):
+    story = _make_story()
+    # Same story twice
+    paths = write_story_articles([story, story], tmp_path)
+    assert len(paths) == 1
+
+
+def test_index_links_all_articles(tmp_path):
+    (tmp_path / "news").mkdir(parents=True)
+    (tmp_path / "topics").mkdir(parents=True)
+    (tmp_path / "digests").mkdir(parents=True)
+    (tmp_path / "news" / "gpt-5-launches.md").write_text("# GPT-5")
+    (tmp_path / "topics" / "ai-agents.md").write_text("# AI Agents")
+    (tmp_path / "digests" / "2026-04-11.md").write_text("# Digest")
+
+    path = write_index(tmp_path)
+
+    content = path.read_text(encoding="utf-8")
+    assert "gpt-5-launches.md" in content
+    assert "ai-agents.md" in content
+    assert "2026-04-11.md" in content
+    assert path == tmp_path / "index.md"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pytest tests/pipeline/test_wiki.py::test_story_article_written tests/pipeline/test_wiki.py::test_story_article_no_llm_call tests/pipeline/test_wiki.py::test_story_article_skips_no_summary tests/pipeline/test_wiki.py::test_story_article_dedupes_by_id tests/pipeline/test_wiki.py::test_index_links_all_articles -v
+```
+
+Expected: `ImportError` — `pipeline.wiki` doesn't exist yet.
+
+- [ ] **Step 3: Create pipeline/wiki.py with helpers + story + index**
+
+```python
+# pipeline/wiki.py
+import json
+import os
+import re
+import tempfile
+from datetime import date, datetime
+from pathlib import Path
+
+from openai import OpenAI
+from schemas.story import Story, StorySummary
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def slugify(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write content to path atomically (best-effort on Windows)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _format_story_article(story: Story) -> str:
+    s = story.summary
+    pub = story.published_at
+    pub_str = pub.strftime("%Y-%m-%d") if hasattr(pub, "strftime") else str(pub)
+    source = story.sources[0].name if story.sources else "Unknown"
+    return "\n".join([
+        f"# {story.title}",
+        "",
+        f"**Source:** {source}",
+        f"**Published:** {pub_str}",
+        f"**URL:** {story.canonical_url}",
+        "",
+        "## What Happened",
+        s.what_happened,
+        "",
+        "## Enterprise Impact",
+        s.enterprise_impact,
+        "",
+        "## Developer Impact",
+        s.developer_impact,
+        "",
+        "## Software Delivery",
+        s.software_delivery_impact,
+        "",
+        "## Human Impact",
+        s.human_impact,
+        "",
+        "## How To Use",
+        s.how_to_use,
+    ])
+
+
+# ── Story articles (no LLM) ───────────────────────────────────────────────────
+
+def write_story_articles(stories: list[Story], wiki_dir: Path) -> list[Path]:
+    """Write one markdown article per story that has a summary. No LLM calls."""
+    seen: set[str] = set()
+    written: list[Path] = []
+    for story in stories:
+        if story.id in seen or story.summary is None:
+            continue
+        seen.add(story.id)
+        slug = slugify(story.title)
+        if not slug:
+            continue
+        path = wiki_dir / "news" / f"{slug}.md"
+        _atomic_write(path, _format_story_article(story))
+        written.append(path)
+    return written
+
+
+# ── Index (no LLM) ────────────────────────────────────────────────────────────
+
+def write_index(wiki_dir: Path) -> Path:
+    """Scan wiki subdirectories and write wiki/index.md."""
+    lines = ["# Wiki Index", ""]
+
+    digests_dir = wiki_dir / "digests"
+    if digests_dir.exists():
+        digest_files = sorted(digests_dir.glob("*.md"), reverse=True)
+        if digest_files:
+            lines.append("## Digests")
+            for f in digest_files:
+                rel = f.relative_to(wiki_dir)
+                lines.append(f"- [{f.stem}]({rel.as_posix()})")
+            lines.append("")
+
+    topics_dir = wiki_dir / "topics"
+    if topics_dir.exists():
+        topic_files = sorted(topics_dir.glob("*.md"))
+        if topic_files:
+            lines.append("## Topics")
+            for f in topic_files:
+                rel = f.relative_to(wiki_dir)
+                lines.append(f"- [{f.stem}]({rel.as_posix()})")
+            lines.append("")
+
+    news_dir = wiki_dir / "news"
+    if news_dir.exists():
+        news_files = sorted(news_dir.glob("*.md"))
+        if news_files:
+            lines.append("## News Articles")
+            for f in news_files:
+                rel = f.relative_to(wiki_dir)
+                lines.append(f"- [{f.stem}]({rel.as_posix()})")
+            lines.append("")
+
+    path = wiki_dir / "index.md"
+    _atomic_write(path, "\n".join(lines))
+    return path
+```
+
+*(Leave the LLM functions for Task 5 — don't add them yet.)*
+
+- [ ] **Step 4: Run tests**
+
+```
+pytest tests/pipeline/test_wiki.py::test_story_article_written tests/pipeline/test_wiki.py::test_story_article_no_llm_call tests/pipeline/test_wiki.py::test_story_article_skips_no_summary tests/pipeline/test_wiki.py::test_story_article_dedupes_by_id tests/pipeline/test_wiki.py::test_index_links_all_articles -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/wiki.py tests/pipeline/test_wiki.py
+git commit -m "feat: wiki.py story articles and index (pure Python)"
+```
+
+---
+
+## Task 5: pipeline/wiki.py — LLM functions + main()
+
+**Files:**
+- Modify: `pipeline/wiki.py` (add topic articles, digest, main)
+- Modify: `tests/pipeline/test_wiki.py` (add LLM tests)
+
+- [ ] **Step 1: Add the LLM tests to tests/pipeline/test_wiki.py**
+
+Append to the end of `tests/pipeline/test_wiki.py`:
+
+```python
+from pipeline.wiki import write_topic_articles, write_digest
+
+
+def test_topic_article_written(tmp_path):
+    story = _make_story(sdlc_tags=["ai-agents"])
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="# AI Agents\n\nContent here."))]
+    )
+    paths = write_topic_articles([story], tmp_path, mock_client, "gemma3")
+
+    assert len(paths) == 1
+    assert paths[0].name == "ai-agents.md"
+    assert "AI Agents" in paths[0].read_text(encoding="utf-8")
+
+
+def test_topic_article_failure_skips(tmp_path):
+    story = _make_story(sdlc_tags=["tooling"])
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = Exception("LLM unavailable")
+
+    # Must not raise — just skip and return empty list
+    paths = write_topic_articles([story], tmp_path, mock_client, "gemma3")
+    assert paths == []
+
+
+def test_digest_date_stamped(tmp_path):
+    story = _make_story()
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="# Weekly Digest\n\nContent."))]
+    )
+    today = date.today().isoformat()
+
+    path = write_digest([story], tmp_path, mock_client, "gemma3")
+
+    assert path is not None
+    assert path.name == f"{today}.md"
+    assert "Weekly Digest" in path.read_text(encoding="utf-8")
+
+
+def test_digest_failure_returns_none(tmp_path):
+    story = _make_story()
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = Exception("LLM error")
+
+    path = write_digest([story], tmp_path, mock_client, "gemma3")
+    assert path is None
+```
+
+- [ ] **Step 2: Run new tests to confirm they fail (ImportError)**
+
+```
+pytest tests/pipeline/test_wiki.py::test_topic_article_written tests/pipeline/test_wiki.py::test_topic_article_failure_skips tests/pipeline/test_wiki.py::test_digest_date_stamped tests/pipeline/test_wiki.py::test_digest_failure_returns_none -v
+```
+
+Expected: `ImportError` — `write_topic_articles` and `write_digest` not yet defined.
+
+- [ ] **Step 3: Add write_topic_articles and write_digest to pipeline/wiki.py**
+
+Append before the final line (or before a `if __name__ == "__main__"` guard if present) in `pipeline/wiki.py`:
+
+```python
+# ── Topic articles (one LLM call per tag) ────────────────────────────────────
+
+def write_topic_articles(
+    stories: list[Story], wiki_dir: Path, client: OpenAI, model: str
+) -> list[Path]:
+    """Write one markdown article per unique sdlc_tag via one LLM call each."""
+    tag_to_stories: dict[str, list[Story]] = {}
+    seen_per_tag: dict[str, set[str]] = {}
+    for story in stories:
+        for tag in story.sdlc_tags:
+            if tag not in tag_to_stories:
+                tag_to_stories[tag] = []
+                seen_per_tag[tag] = set()
+            if story.id not in seen_per_tag[tag]:
+                seen_per_tag[tag].add(story.id)
+                tag_to_stories[tag].append(story)
+
+    written: list[Path] = []
+    for tag, tag_stories in sorted(tag_to_stories.items()):
+        slug = slugify(tag)
+        if not slug:
+            continue
+        path = wiki_dir / "topics" / f"{slug}.md"
+        story_lines = "\n".join(
+            f"- {s.title}: {s.summary.what_happened if s.summary else s.title}"
+            for s in tag_stories
+        )
+        prompt = (
+            f"Write a concise wiki article (200-300 words) about '{tag}' in software delivery and AI.\n"
+            f"Synthesise insights from these recent stories:\n\n{story_lines}\n\n"
+            f"Format as markdown with a # heading and 2-3 short sections. "
+            f"Do not wrap output in a code block."
+        )
+        try:
+            response = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.3,
+            )
+            content = response.choices[0].message.content.strip()
+            _atomic_write(path, content)
+            written.append(path)
+        except Exception as e:
+            print(f"  Warning: topic article failed for '{tag}': {e}")
+    return written
+
+
+# ── Digest (one LLM call from top3) ──────────────────────────────────────────
+
+def write_digest(
+    top3: list[Story], wiki_dir: Path, client: OpenAI, model: str
+) -> Path | None:
+    """Write a weekly digest article from the top 3 stories."""
+    if not top3:
+        return None
+    today = date.today().isoformat()
+    path = wiki_dir / "digests" / f"{today}.md"
+    story_lines = "\n".join(
+        f"- {s.title}: {s.summary.what_happened if s.summary else s.title}"
+        for s in top3
+    )
+    prompt = (
+        f"Write a weekly digest article (200-300 words) summarising the top AI and "
+        f"software delivery stories for {today}.\n"
+        f"Stories:\n\n{story_lines}\n\n"
+        f"Format as markdown with a # heading and a short narrative. "
+        f"Do not wrap output in a code block."
+    )
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.3,
+        )
+        content = response.choices[0].message.content.strip()
+        _atomic_write(path, content)
+        return path
+    except Exception as e:
+        print(f"  Warning: digest failed: {e}")
+        return None
+```
+
+Then add `main()` at the end of `pipeline/wiki.py`:
+
+```python
+# ── Orchestration ─────────────────────────────────────────────────────────────
+
+def main() -> None:
+    from pipeline import llm_config
+
+    wiki_dir = Path(os.environ.get("WIKI_DIR", "D:/myprojects/wiki"))
+    data_path = Path("data/summarized.json")
+
+    raw = json.loads(data_path.read_text(encoding="utf-8"))
+
+    def _story(d: dict) -> Story:
+        if isinstance(d.get("published_at"), str):
+            d["published_at"] = datetime.fromisoformat(d["published_at"])
+        return Story(**d)
+
+    top3 = [_story(s) for s in raw.get("top3", [])]
+    categories: dict[str, list[Story]] = {
+        cat: [_story(s) for s in stories]
+        for cat, stories in raw.get("categories", {}).items()
+    }
+
+    # Collect unique stories for topic articles
+    all_stories: dict[str, Story] = {}
+    for s in top3:
+        all_stories[s.id] = s
+    for stories in categories.values():
+        for s in stories:
+            all_stories.setdefault(s.id, s)
+    all_unique = list(all_stories.values())
+
+    client, model = llm_config.get_client("wiki")
+
+    print("Writing story articles...")
+    story_paths = write_story_articles(all_unique, wiki_dir)
+    for p in story_paths:
+        print(f"  {p}")
+
+    print("Writing topic articles...")
+    topic_paths = write_topic_articles(all_unique, wiki_dir, client, model)
+    for p in topic_paths:
+        print(f"  {p}")
+
+    print("Writing digest...")
+    digest_path = write_digest(top3, wiki_dir, client, model)
+    if digest_path:
+        print(f"  {digest_path}")
+
+    print("Writing index...")
+    index_path = write_index(wiki_dir)
+    print(f"  {index_path}")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run all wiki tests**
+
+```
+pytest tests/pipeline/test_wiki.py -v
+```
+
+Expected: all 9 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/wiki.py tests/pipeline/test_wiki.py
+git commit -m "feat: wiki.py topic articles, digest, and main() orchestration"
+```
+
+---
+
+## Task 6: pipeline/run.py
+
+**Files:**
+- Create: `pipeline/run.py`
+- Create: `tests/pipeline/test_run.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/pipeline/test_run.py
+import sys
+import pytest
+from unittest.mock import patch
+
+
+def test_run_exits_on_ollama_unavailable(monkeypatch):
+    """When LLM_BACKEND=local and Ollama is unreachable, main() must exit(1)."""
+    monkeypatch.setenv("LLM_BACKEND", "local")
+    # Force fresh llm_config load so LLM_BACKEND=local takes effect
+    monkeypatch.delitem(sys.modules, "pipeline.llm_config", raising=False)
+
+    with patch("pipeline.run._ping_ollama", return_value=False):
+        with pytest.raises(SystemExit) as exc:
+            from pipeline import run
+            # Reload run so it picks up fresh llm_config on next main() call
+            import importlib
+            importlib.reload(run)
+            run.main()
+
+    assert exc.value.code == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+pytest tests/pipeline/test_run.py -v
+```
+
+Expected: `ModuleNotFoundError` — `pipeline.run` doesn't exist.
+
+- [ ] **Step 3: Create pipeline/run.py**
+
+```python
+# pipeline/run.py
+"""Local full-pipeline runner. Chains all steps including wiki.
+
+Usage:
+    LLM_BACKEND=local python -m pipeline.run
+"""
+import importlib
+import sys
+
+
+def _ping_ollama(base_url: str = "http://localhost:11434") -> bool:
+    """Return True if Ollama is reachable at the given base URL."""
+    try:
+        import httpx
+        resp = httpx.get(f"{base_url}/api/tags", timeout=5)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def main() -> None:
+    from pipeline import llm_config
+    import os
+
+    if llm_config.LLM_BACKEND == "local":
+        ollama_url = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+        print(f"Pinging Ollama at {ollama_url}...")
+        if not _ping_ollama(ollama_url):
+            print(
+                f"Error: Ollama is not reachable at {ollama_url}.\n"
+                f"Start it with: ollama serve"
+            )
+            sys.exit(1)
+        print("  Ollama is available.")
+
+    steps = [
+        ("fetch", "pipeline.fetch"),
+        ("normalize", "pipeline.normalize"),
+        ("rank", "pipeline.rank"),
+        ("summarize", "pipeline.summarize"),
+        ("wiki", "pipeline.wiki"),
+    ]
+
+    for name, module_path in steps:
+        print(f"\nRunning {name}...")
+        try:
+            mod = importlib.import_module(module_path)
+            mod.main()
+        except Exception as e:
+            print(f"Error in {name}: {e}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run the test**
+
+```
+pytest tests/pipeline/test_run.py -v
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 5: Run the full test suite**
+
+```
+pytest tests/ -v --tb=short
+```
+
+Expected: all tests pass (no regressions across all pipeline tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pipeline/run.py tests/pipeline/test_run.py
+git commit -m "feat: pipeline/run.py local runner with Ollama availability check"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run full test suite one last time**
+
+```
+cd D:/myprojects/newsletteragent
+pytest tests/ -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Smoke test locally (optional — requires Ollama running)**
+
+```
+LLM_BACKEND=local python -m pipeline.wiki
+```
+
+Expected output:
+```
+Writing story articles...
+  D:\myprojects\wiki\news\<slug>.md
+Writing topic articles...
+  D:\myprojects\wiki\topics\<tag>.md
+Writing digest...
+  D:\myprojects\wiki\digests\YYYY-MM-DD.md
+Writing index...
+  D:\myprojects\wiki\index.md
+Done.
+```

--- a/docs/superpowers/specs/2026-04-11-newsletter-wiki-integration-design.md
+++ b/docs/superpowers/specs/2026-04-11-newsletter-wiki-integration-design.md
@@ -1,0 +1,183 @@
+# Newsletter Wiki Integration — Design Spec
+_Date: 2026-04-11_
+
+## Overview
+
+Add wiki integration to the newsletteragent pipeline. A new `pipeline/wiki.py` step reads `data/summarized.json` and writes structured markdown articles to `D:/myprojects/wiki/` (the shared private wiki). A new `pipeline/llm_config.py` module centralises LLM backend selection, enabling the full pipeline to run locally with Gemma3 via Ollama (`LLM_BACKEND=local`) or in CI with GitHub Models (`LLM_BACKEND=github`, default).
+
+---
+
+## Goals
+
+1. Stories from the newsletter feed into the shared wiki alongside discoveryandresearch repo articles
+2. A single env var (`LLM_BACKEND`) switches the entire pipeline between local Gemma3 and CI GPT-4o — no code changes required
+3. CI behaviour is unchanged (no `LLM_BACKEND` set → defaults to `github`)
+
+---
+
+## New Files
+
+| File | Responsibility |
+|---|---|
+| `pipeline/llm_config.py` | Central LLM config — `get_client(step)` returns `(OpenAI, model_name)` |
+| `pipeline/wiki.py` | Wiki build step — reads `summarized.json`, writes to `D:/myprojects/wiki/` |
+| `pipeline/run.py` | Local full-pipeline runner — chains all steps including wiki |
+| `tests/pipeline/test_llm_config.py` | Unit tests for llm_config |
+| `tests/pipeline/test_wiki.py` | Unit tests for wiki step |
+| `tests/pipeline/test_run.py` | Unit test for run.py Ollama availability check |
+
+## Modified Files
+
+| File | Change |
+|---|---|
+| `pipeline/rank.py` | Replace hardcoded `get_client()` with `llm_config.get_client("rank")` |
+| `pipeline/summarize.py` | Replace hardcoded `get_client()` with `llm_config.get_client("summarize")` |
+| `tests/pipeline/test_rank.py` | Update mock target to `pipeline.llm_config.get_client` |
+| `tests/pipeline/test_summarize.py` | Update mock target to `pipeline.llm_config.get_client` |
+
+---
+
+## `pipeline/llm_config.py`
+
+```python
+import os
+from openai import OpenAI
+
+LLM_BACKEND = os.environ.get("LLM_BACKEND", "github")
+
+BACKENDS = {
+    "github": {
+        "base_url": "https://models.github.ai/inference",
+        "api_key": os.environ.get("GITHUB_TOKEN", ""),
+        "models": {
+            "rank":      "openai/gpt-4o-mini",
+            "summarize": "openai/gpt-4o",
+            "wiki":      "openai/gpt-4o-mini",
+        },
+    },
+    "local": {
+        "base_url": "http://localhost:11434/v1",
+        "api_key": "ollama",
+        "models": {
+            "rank":      "gemma3",
+            "summarize": "gemma3",
+            "wiki":      "gemma3",
+        },
+    },
+}
+
+if LLM_BACKEND not in BACKENDS:
+    raise ValueError(f"Unknown LLM_BACKEND '{LLM_BACKEND}'. Must be one of: {list(BACKENDS)}")
+
+
+def get_client(step: str) -> tuple[OpenAI, str]:
+    """Return (OpenAI client, model name) for the given pipeline step."""
+    backend = BACKENDS[LLM_BACKEND]
+    client = OpenAI(base_url=backend["base_url"], api_key=backend["api_key"])
+    return client, backend["models"][step]
+```
+
+---
+
+## Wiki Data Flow
+
+```
+data/summarized.json
+├── top3              list[Story] with full StorySummary
+├── categories        dict[str, list[Story]] by priority_category
+└── enterprise_items  list[Story]
+        │
+        ▼
+1. STORY ARTICLES  — pure Python, NO LLM call
+   All stories from top3 + categories, deduped by Story.id
+   Format StorySummary fields directly into markdown sections:
+   What Happened / Enterprise Impact / Developer Impact /
+   Software Delivery / Human Impact / How To Use
+   → wiki/news/<story-slug>.md
+
+2. TOPIC ARTICLES  — one LLM call per unique sdlc_tag
+   Group stories by sdlc_tags, pass titles + what_happened to LLM
+   → wiki/topics/<tag-slug>.md
+
+3. DIGEST  — one LLM call from top3
+   Pass top3 titles + summaries to LLM for weekly narrative
+   → wiki/digests/YYYY-MM-DD.md
+
+4. INDEX  — pure Python, no LLM call
+   Scan wiki/news/, wiki/topics/, wiki/digests/
+   → wiki/index.md
+```
+
+Wiki output path: `WIKI_DIR` env var, default `D:/myprojects/wiki/`.
+News articles go to `wiki/news/` — no collision with discoveryandresearch `wiki/repos/`.
+
+---
+
+## `pipeline/run.py` (local runner)
+
+```bash
+LLM_BACKEND=local python -m pipeline.run
+```
+
+Steps in order:
+1. If `LLM_BACKEND=local`: ping `http://localhost:11434/api/tags` — exit with clear message if unreachable
+2. `pipeline.fetch.main()`
+3. `pipeline.normalize.main()`
+4. `pipeline.rank.main()`
+5. `pipeline.summarize.main()`
+6. `pipeline.wiki.main()`
+
+Each step's `main()` called directly. Any unhandled exception → print error, `sys.exit(1)`.
+
+---
+
+## Error Handling
+
+- **Unknown `LLM_BACKEND`** — `ValueError` raised at module import time (fail fast)
+- **Ollama unavailable** — ping at `run.py` startup when `LLM_BACKEND=local`; exit before any step runs
+- **Per-LLM-call failures** — topic articles and digest: log warning, skip, continue. Story articles never fail (no LLM).
+- **Step failures in `run.py`** — caught at top level, print error, `sys.exit(1)`
+- **Existing rank/summarize error handling** — unchanged
+
+---
+
+## Testing
+
+### `tests/pipeline/test_llm_config.py`
+
+| Test | What it covers |
+|---|---|
+| `test_github_backend_is_default` | No env var → GitHub Models base_url, correct models per step |
+| `test_local_backend` | `LLM_BACKEND=local` → Ollama base_url, `gemma3` for all steps |
+| `test_unknown_backend_raises` | `LLM_BACKEND=bogus` → `ValueError` |
+
+### `tests/pipeline/test_wiki.py`
+
+| Test | What it covers |
+|---|---|
+| `test_story_article_written` | StorySummary → formatted markdown at `wiki/news/<slug>.md` |
+| `test_story_article_no_llm_call` | Story articles do NOT call `client.chat` |
+| `test_topic_article_written` | Stories with sdlc_tags → `wiki/topics/<tag>.md` via mocked LLM |
+| `test_topic_article_failure_skips` | LLM failure → skip topic, continue |
+| `test_digest_date_stamped` | Digest → `wiki/digests/YYYY-MM-DD.md` |
+| `test_index_links_all_articles` | Wiki dir with files → `index.md` contains all links |
+
+### `tests/pipeline/test_run.py`
+
+| Test | What it covers |
+|---|---|
+| `test_run_exits_on_ollama_unavailable` | `LLM_BACKEND=local` + Ollama unreachable → `sys.exit(1)` before any step |
+
+### Modified existing tests
+
+- `tests/pipeline/test_rank.py` — update mock target from `pipeline.rank.OpenAI` → `pipeline.llm_config.get_client`
+- `tests/pipeline/test_summarize.py` — same update
+
+---
+
+## Out of Scope
+
+- Cross-referencing new stories against existing wiki articles
+- Modifying the CI GitHub Actions workflow
+- Changes to `publish.py` or `deliver.py`
+- Running wiki step in CI (wiki remains local-only)

--- a/pipeline/deliver.py
+++ b/pipeline/deliver.py
@@ -3,7 +3,12 @@ Job 5: Format stories and deliver to Telegram.
 
 Format: Top 3 must-reads in full (HTML), then category digests.
 Uses Telegram HTML parse mode. No emoji except 🔗 on links.
+
+CLI:
+    python pipeline/deliver.py            # send digest + update seen-state
+    python pipeline/deliver.py --dry-run  # skip Telegram, still update seen-state
 """
+import argparse
 import json
 import os
 import asyncio
@@ -11,6 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from telegram import Bot
 from schemas.story import Story
+from pipeline import seen_state
 
 CATEGORY_LABELS = {
     "enterprise_software_delivery": "ENTERPRISE SOFTWARE DELIVERY",
@@ -135,10 +141,17 @@ async def send_to_telegram(text: str, bot_token: str, chat_id: str) -> None:
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Format the digest and update seen-state, but do not send to Telegram."
+    )
+    args = parser.parse_args()
+
     bot_token = os.environ.get("TELEGRAM_BOT_TOKEN")
     chat_id = os.environ.get("TELEGRAM_CHAT_ID")
-    if not bot_token or not chat_id:
-        raise ValueError("TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are required")
+    if not args.dry_run and (not bot_token or not chat_id):
+        raise ValueError("TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are required (or pass --dry-run)")
 
     data = json.loads(Path("data/summarized.json").read_text())
 
@@ -161,8 +174,24 @@ def main():
     digest = format_digest(top3, stories_by_category, week_of=week_of, enterprise_items=enterprise_items)
 
     print(f"Digest length: {len(digest)} characters")
-    asyncio.run(send_to_telegram(digest, bot_token, chat_id))
-    print("Delivered to Telegram.")
+    if args.dry_run:
+        Path("data/digest_preview.txt").write_text(digest, encoding="utf-8")
+        print("DRY RUN: skipped Telegram send. Wrote data/digest_preview.txt")
+    else:
+        asyncio.run(send_to_telegram(digest, bot_token, chat_id))
+        print("Delivered to Telegram.")
+
+    # Update cross-run seen-state only after successful delivery so a Telegram
+    # failure doesn't poison the next run's dedup.
+    delivered_urls = [s.canonical_url for s in top3]
+    for stories in stories_by_category.values():
+        delivered_urls.extend(s.canonical_url for s in stories)
+    delivered_urls.extend(s.canonical_url for s in enterprise_items)
+
+    state = seen_state.load()
+    state = seen_state.add_urls(state, delivered_urls)
+    seen_state.save(state)
+    print(f"Updated seen-state: {len(state['urls'])} URLs in 30d window")
 
 
 if __name__ == "__main__":

--- a/pipeline/normalize.py
+++ b/pipeline/normalize.py
@@ -8,9 +8,24 @@ Dedup strategy:
 Output: data/normalized.json (list of deduplicated Story objects)
 """
 import json
+import re
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 from schemas.story import Story
+from pipeline import seen_state
+
+
+# Navigation/CTA boilerplate that scrapers occasionally surface as "stories".
+# Match is case-insensitive on the stripped title.
+JUNK_EXACT_TITLES = {
+    "sign in", "log in", "enterprise", "skip to content",
+    "weekly issues", "explore courses", "try le chat", "try studio",
+    "subscribe", "menu", "navigation", "search", "home", "contact sales",
+}
+_NAV_TITLE_PATTERN = re.compile(
+    r"^(try |explore |weekly |sign |log |skip |subscribe|menu|search)",
+    re.IGNORECASE,
+)
 
 
 def load_raw_stories(raw_dir: str = "data/raw") -> list[Story]:
@@ -80,6 +95,29 @@ def deduplicate_by_title_similarity(
     return groups
 
 
+def is_junk_title(story: Story) -> bool:
+    title = (story.title or "").strip()
+    title_lower = title.lower()
+    content_len = len(story.raw_content or "")
+    word_count = len(title.split())
+
+    if title_lower in JUNK_EXACT_TITLES:
+        return True
+    if _NAV_TITLE_PATTERN.match(title) and content_len < 80:
+        return True
+    if word_count <= 2 and content_len < 60:
+        return True
+    return False
+
+
+def filter_junk(stories: list[Story]) -> list[Story]:
+    return [s for s in stories if not is_junk_title(s)]
+
+
+def filter_seen(stories: list[Story], seen_urls: set[str]) -> list[Story]:
+    return [s for s in stories if s.canonical_url not in seen_urls]
+
+
 def filter_older_than_days(stories: list[Story], days: int = 7) -> list[Story]:
     cutoff = datetime.now(tz=timezone.utc) - timedelta(days=days)
     return [
@@ -95,11 +133,18 @@ def normalize(raw_dir: str = "data/raw") -> list[Story]:
     stories = filter_older_than_days(stories, days=7)
     print(f"  After age filter: {len(stories)}")
 
+    stories = filter_junk(stories)
+    print(f"  After junk-title filter: {len(stories)}")
+
     stories = deduplicate_by_url(stories)
     print(f"  After URL dedup: {len(stories)}")
 
     stories = deduplicate_by_title_similarity(stories, threshold=0.6)
     print(f"  After title similarity dedup: {len(stories)}")
+
+    seen = seen_state.seen_url_set(seen_state.load())
+    stories = filter_seen(stories, seen)
+    print(f"  After cross-run dedup ({len(seen)} URLs in 30d window): {len(stories)}")
 
     # Sort by source_count desc, then published_at desc
     stories.sort(key=lambda s: (s.source_count, s.published_at), reverse=True)

--- a/pipeline/seen_state.py
+++ b/pipeline/seen_state.py
@@ -1,0 +1,80 @@
+"""
+Cross-run dedup state.
+
+Tracks URLs that have appeared in past delivered digests so the pipeline can
+hide them on subsequent runs. Persisted at `state/seen.json` and committed
+back to the repo by the workflow on successful delivery.
+
+Schema (v1):
+    {
+      "version": 1,
+      "urls": [
+        {"url": "https://...", "seen_at": "2026-05-04T14:40:22+00:00"},
+        ...
+      ]
+    }
+
+Entries older than RETENTION_DAYS are pruned on load.
+"""
+import json
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+DEFAULT_PATH = Path("state/seen.json")
+RETENTION_DAYS = 30
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def load(path: Path = DEFAULT_PATH) -> dict:
+    """Load seen-state, pruning entries older than RETENTION_DAYS.
+
+    Returns the canonical in-memory shape:
+        {"version": 1, "urls": [{"url": str, "seen_at": iso}, ...]}
+    """
+    if not path.exists():
+        return {"version": 1, "urls": []}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"version": 1, "urls": []}
+
+    cutoff = _now() - timedelta(days=RETENTION_DAYS)
+    kept = []
+    for entry in data.get("urls", []):
+        url = entry.get("url")
+        seen_at_raw = entry.get("seen_at")
+        if not url or not seen_at_raw:
+            continue
+        try:
+            seen_at = datetime.fromisoformat(seen_at_raw.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if seen_at.tzinfo is None:
+            seen_at = seen_at.replace(tzinfo=timezone.utc)
+        if seen_at >= cutoff:
+            kept.append({"url": url, "seen_at": seen_at.isoformat()})
+    return {"version": 1, "urls": kept}
+
+
+def seen_url_set(state: dict) -> set[str]:
+    return {entry["url"] for entry in state.get("urls", []) if entry.get("url")}
+
+
+def add_urls(state: dict, urls: list[str]) -> dict:
+    """Merge new URLs into state. Refreshes seen_at for any that already exist."""
+    now_iso = _now().isoformat()
+    by_url = {entry["url"]: entry for entry in state.get("urls", [])}
+    for url in urls:
+        if not url:
+            continue
+        by_url[url] = {"url": url, "seen_at": now_iso}
+    state["urls"] = list(by_url.values())
+    return state
+
+
+def save(state: dict, path: Path = DEFAULT_PATH) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2), encoding="utf-8")

--- a/scripts/test_filters_local.py
+++ b/scripts/test_filters_local.py
@@ -1,0 +1,230 @@
+"""
+Offline test harness for proposed normalize-stage improvements.
+
+Runs three candidate filters against a real normalized.json corpus
+(downloaded from a recent workflow run via `gh run download`) and
+prints before/after counts plus samples of dropped items so you can
+sanity-check that nothing real is being killed.
+
+No LLM calls. No mutations to the pipeline. Pure diagnostic.
+
+Usage:
+    python scripts/test_filters_local.py [path/to/normalized.json] \
+        [path/to/prior/summarized.json]
+
+Defaults:
+    corpus  = tmp_real_run/normalized/normalized.json
+    seen    = tmp_latest/summarized.json
+"""
+import json
+import re
+import sys
+
+# Force UTF-8 stdout on Windows so we can print non-cp1252 chars in titles.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+
+# ---- Filter A: tighter recency cutoff -------------------------------------
+
+def filter_recency(stories: list[dict], max_age_days: int) -> tuple[list, list]:
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(days=max_age_days)
+    kept, dropped = [], []
+    for s in stories:
+        pub = s.get("published_at")
+        if isinstance(pub, str):
+            try:
+                pub_dt = datetime.fromisoformat(pub.replace("Z", "+00:00"))
+            except ValueError:
+                kept.append(s)
+                continue
+        else:
+            kept.append(s)
+            continue
+        if pub_dt.tzinfo is None:
+            pub_dt = pub_dt.replace(tzinfo=timezone.utc)
+        if pub_dt >= cutoff:
+            kept.append(s)
+        else:
+            dropped.append(s)
+    return kept, dropped
+
+
+# ---- Filter B: junk-title / nav-boilerplate filter ------------------------
+
+JUNK_EXACT_TITLES = {
+    "sign in", "log in", "enterprise", "skip to content",
+    "weekly issues", "explore courses", "try le chat", "try studio",
+    "subscribe", "menu", "navigation", "search", "home",
+}
+NAV_TITLE_PATTERN = re.compile(
+    r"^(try |explore |weekly |sign |log |skip |subscribe|menu|search)",
+    re.IGNORECASE,
+)
+
+
+def is_junk(story: dict) -> tuple[bool, str]:
+    title = (story.get("title") or "").strip()
+    title_lower = title.lower()
+    content_len = len(story.get("raw_content") or "")
+    word_count = len(title.split())
+
+    if title_lower in JUNK_EXACT_TITLES:
+        return True, "exact-blocklist"
+    # Nav-style phrasing AND short content => junk
+    if NAV_TITLE_PATTERN.match(title) and content_len < 80:
+        return True, f"nav-pattern+short(content_len={content_len})"
+    # Very short title AND very short content => junk
+    if word_count <= 2 and content_len < 60:
+        return True, f"short-title+short-content(words={word_count},content_len={content_len})"
+    return False, ""
+
+
+def filter_junk(stories: list[dict]) -> tuple[list, list]:
+    kept, dropped = [], []
+    for s in stories:
+        junk, reason = is_junk(s)
+        if junk:
+            dropped.append((s, reason))
+        else:
+            kept.append(s)
+    return kept, dropped
+
+
+# ---- Filter C: cross-run dedup --------------------------------------------
+
+def load_seen(seen_path: Path) -> set[str]:
+    if not seen_path.exists():
+        return set()
+    data = json.loads(seen_path.read_text(encoding="utf-8"))
+    seen: set[str] = set()
+    # Plain list of URLs (e.g. tmp_runs/_seen_combined.json)
+    if isinstance(data, list) and data and isinstance(data[0], str):
+        return {u for u in data if u}
+    if isinstance(data, dict):
+        for s in data.get("top3", []) or []:
+            url = s.get("canonical_url")
+            if url:
+                seen.add(url)
+        for items in (data.get("categories") or {}).values():
+            for s in items or []:
+                url = s.get("canonical_url")
+                if url:
+                    seen.add(url)
+    elif isinstance(data, list):
+        for s in data:
+            url = s.get("canonical_url")
+            if url:
+                seen.add(url)
+    return seen
+
+
+def filter_cross_run(stories: list[dict], seen_urls: set[str]) -> tuple[list, list]:
+    kept, dropped = [], []
+    for s in stories:
+        if s.get("canonical_url") in seen_urls:
+            dropped.append(s)
+        else:
+            kept.append(s)
+    return kept, dropped
+
+
+# ---- Reporting ------------------------------------------------------------
+
+def print_drop_samples(label: str, dropped, limit: int = 10):
+    print(f"\n  --- {label}: {len(dropped)} dropped (showing up to {limit}) ---")
+    for item in dropped[:limit]:
+        if isinstance(item, tuple):
+            s, reason = item
+            print(f"    [{reason}] {repr((s.get('title') or '')[:80])}")
+        else:
+            s = item
+            pub = (s.get("published_at") or "")[:10]
+            print(f"    [{pub}] {repr((s.get('title') or '')[:80])}")
+
+
+def main():
+    corpus_path = Path(sys.argv[1] if len(sys.argv) > 1
+                       else "tmp_real_run/normalized/normalized.json")
+    seen_path = Path(sys.argv[2] if len(sys.argv) > 2
+                     else "tmp_latest/summarized.json")
+
+    if not corpus_path.exists():
+        print(f"ERROR: corpus not found: {corpus_path}")
+        print("Hint: gh run download <run-id> --dir tmp_real_run")
+        sys.exit(1)
+
+    stories = json.loads(corpus_path.read_text(encoding="utf-8"))
+    print(f"Corpus: {corpus_path} ({len(stories)} stories)")
+
+    seen = load_seen(seen_path)
+    print(f"Prior-run seen URLs: {len(seen)} (from {seen_path})")
+
+    # NB: corpus is dated relative to when the run executed, so a 5-day
+    # cutoff "now" may drop almost everything if the corpus is old.
+    # We anchor recency against the freshest published_at in the corpus
+    # to make the test meaningful regardless of corpus age.
+    pub_dates = []
+    for s in stories:
+        p = s.get("published_at")
+        if isinstance(p, str):
+            try:
+                pub_dates.append(datetime.fromisoformat(p.replace("Z", "+00:00")))
+            except ValueError:
+                pass
+    if pub_dates:
+        anchor = max(pub_dates)
+        print(f"Recency anchor (newest item in corpus): {anchor.isoformat()}")
+    else:
+        anchor = datetime.now(tz=timezone.utc)
+
+    # --- A: recency 5d (anchored) ---
+    cutoff_5d = anchor - timedelta(days=5)
+    cutoff_7d = anchor - timedelta(days=7)
+    kept_5d, drop_5d = [], []
+    kept_7d, drop_7d = [], []
+    for s in stories:
+        p = s.get("published_at")
+        try:
+            pdt = datetime.fromisoformat(p.replace("Z", "+00:00"))
+        except (ValueError, AttributeError, TypeError):
+            kept_5d.append(s); kept_7d.append(s); continue
+        if pdt.tzinfo is None:
+            pdt = pdt.replace(tzinfo=timezone.utc)
+        (kept_5d if pdt >= cutoff_5d else drop_5d).append(s)
+        (kept_7d if pdt >= cutoff_7d else drop_7d).append(s)
+
+    print(f"\n[A] Recency filter (anchored to newest item in corpus)")
+    print(f"  7-day cutoff: keep {len(kept_7d)}, drop {len(drop_7d)}")
+    print(f"  5-day cutoff: keep {len(kept_5d)}, drop {len(drop_5d)}")
+    print_drop_samples("Items only 5d would drop (kept by 7d)",
+                       [s for s in drop_5d if s in kept_7d])
+
+    # --- B: junk filter ---
+    kept_junk, drop_junk = filter_junk(stories)
+    print(f"\n[B] Junk-title filter")
+    print(f"  keep {len(kept_junk)}, drop {len(drop_junk)}")
+    print_drop_samples("junk dropped", drop_junk, limit=20)
+
+    # --- C: cross-run dedup ---
+    kept_cr, drop_cr = filter_cross_run(stories, seen)
+    print(f"\n[C] Cross-run dedup against last run's selections")
+    print(f"  keep {len(kept_cr)}, drop {len(drop_cr)}")
+    print_drop_samples("cross-run duplicates", drop_cr)
+
+    # --- Combined effect ---
+    after_a = kept_5d
+    after_ab_set_ids = {id(s) for s in after_a}
+    after_ab = [s for s in kept_junk if id(s) in after_ab_set_ids]
+    after_abc = [s for s in after_ab if s.get("canonical_url") not in seen]
+    print(f"\n[Combined] start={len(stories)} -> 5d={len(after_a)} "
+          f"-> +junk={len(after_ab)} -> +cross-run={len(after_abc)}")
+    print(f"  total dropped: {len(stories) - len(after_abc)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/state/seen.json
+++ b/state/seen.json
@@ -108,6 +108,50 @@
     {
       "url": "https://deepmind.google/blog/announcing-our-partnership-with-the-republic-of-korea/",
       "seen_at": "2026-05-09T23:45:57.786128+00:00"
+    },
+    {
+      "url": "https://www.claude.com/blog/building-agents-that-reach-production-systems-with-mcp",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
+    },
+    {
+      "url": "https://devblogs.microsoft.com/microsoft365dev/announcing-the-public-preview-of-the-microsoft-365-copilot-agent-evaluations-tool/",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
+    },
+    {
+      "url": "https://www.claude.com/blog/new-guide-deploying-claude-across-the-enterprise-with-claude-cowork",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
+    },
+    {
+      "url": "https://www.anthropic.com/engineering/april-23-postmortem",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
+    },
+    {
+      "url": "https://github.blog/changelog/2026-05-08-more-flexible-secrets-and-variables-for-copilot-cloud-agent",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
+    },
+    {
+      "url": "https://aws.amazon.com/blogs/machine-learning/cost-effective-deployment-of-vision-language-models-for-pet-behavior-detection-on-aws-inferentia2/",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
+    },
+    {
+      "url": "https://www.anthropic.com/news/anthropic-amazon-compute",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
+    },
+    {
+      "url": "https://www.anthropic.com/news/finance-agents",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
+    },
+    {
+      "url": "https://the-decoder.com/mozillas-agentic-ai-pipeline-turns-claude-mythos-preview-loose-and-finds-271-unknown-firefox-vulnerabilities/",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
+    },
+    {
+      "url": "https://openai.com/index/running-codex-safely",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
+    },
+    {
+      "url": "https://openai.com/index/advancing-voice-intelligence-with-new-models-in-the-api",
+      "seen_at": "2026-05-09T23:51:46.026330+00:00"
     }
   ]
 }

--- a/state/seen.json
+++ b/state/seen.json
@@ -1,0 +1,113 @@
+{
+  "version": 1,
+  "urls": [
+    {
+      "url": "https://www.anthropic.com/engineering/advanced-tool-use",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://www.claude.com/blog/claude-platform-compliance-api",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://openai.com/index/cloudflare-openai-agent-cloud",
+      "seen_at": "2026-04-13T14:30:13+00:00"
+    },
+    {
+      "url": "https://www.claude.com/blog/claude-managed-agents",
+      "seen_at": "2026-04-13T14:30:13+00:00"
+    },
+    {
+      "url": "https://aws.amazon.com/blogs/machine-learning/accelerate-agentic-tool-calling-with-serverless-model-customization-in-amazon-sagemaker-ai/",
+      "seen_at": "2026-04-13T14:30:13+00:00"
+    },
+    {
+      "url": "https://www.anthropic.com/engineering/code-execution-with-mcp",
+      "seen_at": "2026-04-13T14:30:13+00:00"
+    },
+    {
+      "url": "https://openai.com/index/cyberagent",
+      "seen_at": "2026-04-13T14:30:13+00:00"
+    },
+    {
+      "url": "https://openai.com/index/next-phase-of-enterprise-ai/",
+      "seen_at": "2026-04-13T14:30:13+00:00"
+    },
+    {
+      "url": "https://www.latent.space/p/ainews-anthropic-30b-arr-project",
+      "seen_at": "2026-04-13T14:30:13+00:00"
+    },
+    {
+      "url": "https://www.anthropic.com/news/claude-opus-4-7",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://aws.amazon.com/blogs/machine-learning/nova-forge-sdk-series-part-2-practical-guide-to-fine-tune-nova-models-using-data-mixing-capabilities/",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://openai.com/index/the-next-evolution-of-the-agents-sdk",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://www.anthropic.com/news/claude-design-anthropic-labs",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://www.claude.com/blog/cowork-for-enterprise",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://www.anthropic.com/news/claude-partner-network",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://simonwillison.net/2026/Apr/14/trusted-access-openai/#atom-everything",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://deepmind.google/blog/gemini-3-1-flash-tts-the-next-generation-of-expressive-ai-speech/",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://deepmind.google/blog/gemini-robotics-er-1-6/",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://www.latent.space/p/ainews-anthropic-claude-opus-47-literally",
+      "seen_at": "2026-04-20T14:30:34+00:00"
+    },
+    {
+      "url": "https://www.latent.space/p/ainews-gpt-55-and-openai-codex-superapp",
+      "seen_at": "2026-05-09T23:45:57.786128+00:00"
+    },
+    {
+      "url": "https://azure.microsoft.com/en-us/blog/openais-gpt-5-5-in-microsoft-foundry-frontier-intelligence-on-an-enterprise-ready-platform/",
+      "seen_at": "2026-05-09T23:45:57.786128+00:00"
+    },
+    {
+      "url": "https://aws.amazon.com/blogs/machine-learning/from-developer-desks-to-the-whole-organization-running-claude-cowork-in-amazon-bedrock/",
+      "seen_at": "2026-05-09T23:45:57.786128+00:00"
+    },
+    {
+      "url": "https://deepmind.google/blog/decoupled-diloco/",
+      "seen_at": "2026-05-09T23:45:57.786128+00:00"
+    },
+    {
+      "url": "https://www.anthropic.com/engineering/desktop-extensions",
+      "seen_at": "2026-05-09T23:45:57.786128+00:00"
+    },
+    {
+      "url": "https://www.salesforce.com/blog/customer-success-awards/",
+      "seen_at": "2026-05-09T23:45:57.786128+00:00"
+    },
+    {
+      "url": "https://deepmind.google/blog/partnering-with-industry-leaders-to-accelerate-ai-transformation/",
+      "seen_at": "2026-05-09T23:45:57.786128+00:00"
+    },
+    {
+      "url": "https://deepmind.google/blog/announcing-our-partnership-with-the-republic-of-korea/",
+      "seen_at": "2026-05-09T23:45:57.786128+00:00"
+    }
+  ]
+}


### PR DESCRIPTION
- Junk-title filter drops navigation boilerplate (Sign in, Enterprise, Skip to content, etc.) by exact-match + short-content heuristics.
- Cross-run dedup hides URLs delivered in any of the last ~30 days, persisted at `state/seen.json` and committed back by the workflow on successful delivery.
- `workflow_dispatch.inputs.dry_run` added so future verification runs can skip Telegram and upload a `digest-preview` artifact.
Dry-run on this branch — [Actions run 25614814196](https://github.com/nayyarsan/mynewsletters/actions/runs/25614814196):
```
Loaded 281 raw stories
After age filter: 252      (−29)
After junk-title filter: 245  (−7  ← new)
After URL dedup: 243       (−2)
After title dedup: 243     (−0)
After cross-run dedup: 238 (−5  ← new, already-featured Anthropic items)
```
Auto-commit of `state/seen.json` landed correctly with `[skip ci]`. All 93 existing tests pass.
- [x] Offline diagnostic on real corpus shows 8 junk dropped, 0 false positives
- [x] Cross-run dedup drops 5 already-featured items
- [x] End-to-end dry-run workflow on branch succeeded
- [x] Auto-commit of seen-state on branch worked
- [ ] Next Monday's scheduled run uses the new filters (no Telegram side-effect needed to verify — happens naturally)